### PR TITLE
Added --help and --version options to hotspot v4.1.0 binary

### DIFF
--- a/hotspot-distr/hotspot-deploy/src/Cluster.hpp
+++ b/hotspot-distr/hotspot-deploy/src/Cluster.hpp
@@ -23,6 +23,12 @@
 
 namespace hotspot
 {
+    // Print version statement
+    void Version();
+
+    // Print usage statement
+    void Usage(std::ostream& outputStream);
+
 	// Process program Input
 	void GetArgs (int argc, char **argv);
 


### PR DESCRIPTION
(Hi Bob, just to explain, this is a "pull request", which means anyone can submit code, which you can decide whether or not to approve going into your project's source code. You can review the changes by clicking on the "Files changed" tab above this message window.)

I added code so that users can type in the option `-h` or `--help` to get a usage statement sent to standard output (exiting with a zero error code), and `-v` or `--version` to get the hotspot binary version and author/citation details sent to standard output (exiting with a zero error code). 

If the incorrect number of arguments are specified, the binary still prints the same usage statement, but it is sent to standard error (exiting with the same non-zero error code as before).

These options work by throwing different types of custom exceptions, which can be modified in and added to in the `hotspot` namespace in `Cluster.cpp`, as more options are added down the road. The `hotspot` namespace is also where the version, author and citation strings are kept, for easy modification as new versions of the application are published.

The `--version` option format tries to follow the pattern used in BEDOPS tools, although the layout and content is easily modified by editing the output of the `hotspot::Version()` function in `Cluster.cpp`.
